### PR TITLE
ci: use version 0.0.0 for alpha publish and tag as alpha

### DIFF
--- a/.github/workflows/alpha-publish.yml
+++ b/.github/workflows/alpha-publish.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Get current version
-        id: package_version
-        run: echo "current_version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-
       - name: Get short SHA
         id: short_sha
         run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -39,12 +35,12 @@ jobs:
       - name: Update version
         id: update_version
         run: |
-          NEW_VERSION="${{ steps.package_version.outputs.current_version }}-alpha.${{ steps.date.outputs.date }}-${{ steps.short_sha.outputs.sha }}"
+          NEW_VERSION="0.0.0-alpha.${{ steps.date.outputs.date }}-${{ steps.short_sha.outputs.sha }}"
           npm version $NEW_VERSION --no-git-tag-version
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Publish to NPM
-        run: npm publish --access public
+        run: npm publish --tag alpha
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -53,7 +49,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
 
       - name: Publish to GitHub Packages
-        run: npm publish
+        run: npm publish --tag alpha
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# Description

This PR updates the `alpha-publish` workflow. When an alpha version is published, the base version will be 0.0.0 with the tag of `alpha`.

This would indicate more explicitly that the alpha versions should not be used unless they're in a development or testing environment. The tag `alpha` will not interfere with the `latest` tag (the default tag) that the users install by default when no version is given.

# Checklist

<!-- Append "N/A" at the end of the item to indicate if it's not applicable -->
<!-- E.g. - [ ] ~updated storybook~ N/A, no new components -->
<!-- Prepend "POST-MERGE: " to indicate it will be completed after the merge -->
<!-- E.g. - [ ] POST-MERGE: ramp the feature flag -->

- [x] My PR represents one logical piece of work
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that prove my fix is effective or that my feature works N/A
