### PR TITLE
feat: remove /api/v2 from the trackingApiBaseUrl

### DIFF
--- a/src/tracker.test.ts
+++ b/src/tracker.test.ts
@@ -281,7 +281,7 @@ describe('TESTING Tracker', () => {
 				it('SHOULD send the request to the specified trackingApiBaseUrl', () => {
 					expect(fetch).toHavePostedTimes(
 						1,
-						'https://my-vero-proxy.example.com/users/track?tracking_api_key=test-api-key',
+						'https://my-vero-proxy.example.com/api/v2/users/track?tracking_api_key=test-api-key',
 						{
 							body: {
 								id: 'test-user-id',
@@ -314,7 +314,7 @@ describe('TESTING Tracker', () => {
 				it('SHOULD send the request to the specified trackingApiBaseUrl', () => {
 					expect(fetch).toHavePutTimes(
 						1,
-						'https://my-vero-proxy.example.com/users/reidentify?tracking_api_key=test-api-key',
+						'https://my-vero-proxy.example.com/api/v2/users/reidentify?tracking_api_key=test-api-key',
 						{
 							body: {
 								id: 'test-user-id',
@@ -335,7 +335,7 @@ describe('TESTING Tracker', () => {
 				it('SHOULD send the request to the specified trackingApiBaseUrl', () => {
 					expect(fetch).toHavePostedTimes(
 						1,
-						'https://my-vero-proxy.example.com/users/unsubscribe?tracking_api_key=test-api-key',
+						'https://my-vero-proxy.example.com/api/v2/users/unsubscribe?tracking_api_key=test-api-key',
 						{
 							body: {
 								id: 'test-user-id',
@@ -355,7 +355,7 @@ describe('TESTING Tracker', () => {
 				it('SHOULD send the request to the specified trackingApiBaseUrl', () => {
 					expect(fetch).toHavePostedTimes(
 						1,
-						'https://my-vero-proxy.example.com/users/resubscribe?tracking_api_key=test-api-key',
+						'https://my-vero-proxy.example.com/api/v2/users/resubscribe?tracking_api_key=test-api-key',
 						{
 							body: {
 								id: 'test-user-id',
@@ -375,7 +375,7 @@ describe('TESTING Tracker', () => {
 				it('SHOULD send the request to the specified trackingApiBaseUrl', () => {
 					expect(fetch).toHavePostedTimes(
 						1,
-						'https://my-vero-proxy.example.com/users/delete?tracking_api_key=test-api-key',
+						'https://my-vero-proxy.example.com/api/v2/users/delete?tracking_api_key=test-api-key',
 						{
 							body: {
 								id: 'test-user-id',
@@ -397,7 +397,7 @@ describe('TESTING Tracker', () => {
 				it('SHOULD send the request to the specified trackingApiBaseUrl', async () => {
 					expect(fetch).toHavePutTimes(
 						1,
-						'https://my-vero-proxy.example.com/users/tags/edit?tracking_api_key=test-api-key',
+						'https://my-vero-proxy.example.com/api/v2/users/tags/edit?tracking_api_key=test-api-key',
 						{
 							body: {
 								id: 'test-user-id',
@@ -431,7 +431,7 @@ describe('TESTING Tracker', () => {
 				it('SHOULD track the event by sending the request to the specified trackingApiBaseUrl', () => {
 					expect(fetch).toHavePostedTimes(
 						1,
-						'https://my-vero-proxy.example.com/events/track?tracking_api_key=test-api-key',
+						'https://my-vero-proxy.example.com/api/v2/events/track?tracking_api_key=test-api-key',
 						{
 							body: {
 								identity: {

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -16,7 +16,21 @@ import throwError from './utils/throwError';
 import type { Optional } from './utils/types';
 
 export interface TrackerOptions {
+	/**
+	 * The tracking API key of your project. You can find it or create a new one on the Settings page of your
+	 * Vero project.
+	 *
+	 * @see https://connect.getvero.com/settings/project/tracking-api-keys
+	 */
 	trackingApiKey: string;
+	/**
+	 * The base URL of the Vero API.
+	 *
+	 * Some browser content blockers (e.g., uBlock Origin) may block requests to the Vero API. In this case, you can
+	 * set up a reverse proxy to the Vero API and set this option to the URL of the reverse proxy.
+	 *
+	 * @default "https://api.getvero.com"
+	 */
 	trackingApiBaseUrl?: string;
 	/**
 	 * When you call {@link Tracker#user.identify}, the user's identity is stored in this {@link IdentityStore}.
@@ -208,7 +222,7 @@ class Tracker {
 
 	constructor(options: TrackerOptions) {
 		this.network = new Network(
-			options.trackingApiBaseUrl ?? 'https://api.getvero.com/api/v2',
+			options.trackingApiBaseUrl ?? 'https://api.getvero.com',
 			options.trackingApiKey,
 		);
 
@@ -259,7 +273,7 @@ class Tracker {
 		 * @param request {@link UserIdentifyRequest}
 		 */
 		identify: async (request: UserIdentifyRequest) => {
-			await this.network.send('/users/track', 'POST', {
+			await this.network.send('/api/v2/users/track', 'POST', {
 				id: request.id,
 				email: request.email,
 				channels: request.channels ?? [],
@@ -299,7 +313,7 @@ class Tracker {
 		 */
 		alias: async (request: UserAliasRequest) => {
 			const userId = this.getUserId(request);
-			await this.network.send('/users/reidentify', 'PUT', {
+			await this.network.send('/api/v2/users/reidentify', 'PUT', {
 				id: userId,
 				new_id: request.newId,
 			});
@@ -316,7 +330,7 @@ class Tracker {
 		 */
 		unsubscribe: async (request?: UserUnsubscribeRequest) => {
 			const userId = this.getUserId(request);
-			await this.network.send('/users/unsubscribe', 'POST', {
+			await this.network.send('/api/v2/users/unsubscribe', 'POST', {
 				id: userId,
 			});
 		},
@@ -327,7 +341,7 @@ class Tracker {
 		 */
 		resubscribe: async (request?: UserResubscribeRequest) => {
 			const userId = this.getUserId(request);
-			await this.network.send('/users/resubscribe', 'POST', {
+			await this.network.send('/api/v2/users/resubscribe', 'POST', {
 				id: userId,
 			});
 		},
@@ -338,7 +352,7 @@ class Tracker {
 		 */
 		delete: async (request?: UserDeleteRequest) => {
 			const userId = this.getUserId(request);
-			await this.network.send('/users/delete', 'POST', {
+			await this.network.send('/api/v2/users/delete', 'POST', {
 				id: userId,
 			});
 			if (userId === this.identityStore?.get()?.userId) {
@@ -355,7 +369,7 @@ class Tracker {
 		 */
 		edit: async (request: TagEditRequest) => {
 			const userId = this.getUserId(request);
-			await this.network.send('/users/tags/edit', 'PUT', {
+			await this.network.send('/api/v2/users/tags/edit', 'PUT', {
 				id: userId,
 				add: request.add ?? [],
 				remove: request.remove ?? [],
@@ -423,7 +437,7 @@ class Tracker {
 			};
 		},
 	) {
-		await this.network.send('/events/track', 'POST', {
+		await this.network.send('/api/v2/events/track', 'POST', {
 			identity: {
 				id: request.identity.userId,
 				email: request.identity.email,


### PR DESCRIPTION
# Description

Remove `/api/v2` from the `TrackerOptions.trackingApiBaseUrl`. This would give us more flexibility in the future if we use the endpoints not under `/api/v2` (such as other versions of the API).

# Checklist

<!-- Append "N/A" at the end of the item to indicate if it's not applicable -->
<!-- E.g. - [ ] ~updated storybook~ N/A, no new components -->
<!-- Prepend "POST-MERGE: " to indicate it will be completed after the merge -->
<!-- E.g. - [ ] POST-MERGE: ramp the feature flag -->

- [x] My PR represents one logical piece of work
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BREAKING CHANGE: the default `TrackerOptions.trackingApiBaseUrl` no longer has `/api/v2` appended. When a request is sent by the `Tracker` class, it will append `/api/v2` to the `trackingApiBaseUrl`.