### PR TITLE
fix: identified user data timezone should be timezone offset; add ianaTimezone as a new reserved property

### DIFF
--- a/src/tracker.test.ts
+++ b/src/tracker.test.ts
@@ -507,7 +507,8 @@ describe('TESTING Tracker', () => {
 			jest.spyOn(isBrowserModule, 'default').mockReturnValue(true);
 			jest.spyOn(getDefaultReservedUserDataModule, 'default').mockReturnValue({
 				language: 'en',
-				timezone: 'Australia/Sydney',
+				timezone: 10,
+				ianaTimezone: 'Australia/Sydney',
 				userAgent:
 					'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
 			});
@@ -586,7 +587,8 @@ describe('TESTING Tracker', () => {
 									first_name: 'test',
 									last_name: 'test',
 									language: 'en',
-									timezone: 'Australia/Sydney',
+									timezone: 10,
+									ianaTimezone: 'Australia/Sydney',
 									userAgent:
 										'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
 								},
@@ -617,7 +619,8 @@ describe('TESTING Tracker', () => {
 								event_name: 'Visited site',
 								data: {
 									language: 'en',
-									timezone: 'Australia/Sydney',
+									timezone: 10,
+									ianaTimezone: 'Australia/Sydney',
 									userAgent:
 										'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
 								},
@@ -1004,7 +1007,8 @@ describe('TESTING Tracker', () => {
 								data: {
 									test: 'test',
 									language: 'en',
-									timezone: 'Australia/Sydney',
+									timezone: 10,
+									ianaTimezone: 'Australia/Sydney',
 									userAgent:
 										'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
 								},
@@ -1045,7 +1049,8 @@ describe('TESTING Tracker', () => {
 									data: {
 										test: 'test',
 										language: 'en',
-										timezone: 'Australia/Sydney',
+										timezone: 10,
+										ianaTimezone: 'Australia/Sydney',
 										userAgent:
 											'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
 									},

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -109,8 +109,8 @@ export interface UserIdentifyRequest extends NoSiteVisitEventRequest {
 	/**
 	 * An object containing key value pairs that represent the custom user properties you want to update.
 	 *
-	 * In the browser environment, the `language`, `timezone` and `userAgent` attributes are reserved properties
-	 * that will be automatically populated by the SDK. If any of these attributes are defined in the request,
+	 * In the browser environment, the `language`, `timezone`, `ianaTimezone` and `userAgent` attributes are reserved
+	 * properties that will be automatically populated by the SDK. If any of these attributes are defined in the request,
 	 * they will be overwritten by the SDK.
 	 *
 	 * All other keys are freeform and can be defined by you.

--- a/src/utils/getDefaultReservedUserData.ts
+++ b/src/utils/getDefaultReservedUserData.ts
@@ -4,7 +4,8 @@ const getDefaultReservedUserData = () => {
 	if (isBrowser()) {
 		return {
 			language: window.navigator.language,
-			timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+			timezone: (new Date().getTimezoneOffset() / 60) * -1,
+			ianaTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 			userAgent: window.navigator.userAgent,
 		};
 	}


### PR DESCRIPTION
# Description

The `timezone` property in the reserved user data should be a number representing the timezone offset (e.g. 11 for AEDT) but instead, an IANA timezone identifier is given. This will break existing users' CDPs.

This PR changes that property and is set to the timezone offset. It also now adds a new reserved property `ianaTimezone` which returns the IANA timezone identifier (e.g. Australia/Sydney).

# Checklist

<!-- Append "N/A" at the end of the item to indicate if it's not applicable -->
<!-- E.g. - [ ] ~updated storybook~ N/A, no new components -->
<!-- Prepend "POST-MERGE: " to indicate it will be completed after the merge -->
<!-- E.g. - [ ] POST-MERGE: ramp the feature flag -->

- [x] My PR represents one logical piece of work
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
