### PR TITLE
ci: update alpha release workflow on manual trigger only

### DIFF
--- a/.github/workflows/on-alpha-release.yml
+++ b/.github/workflows/on-alpha-release.yml
@@ -1,0 +1,12 @@
+name: Create Alpha Release
+
+on: workflow_dispatch
+
+jobs:
+  lint-and-test:
+    uses: ./.github/workflows/lint-and-test.yml
+
+  publish-alpha:
+    needs: lint-and-test
+    uses: ./.github/workflows/alpha-publish.yml
+    secrets: inherit

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -7,8 +7,3 @@ on:
 jobs:
   lint-and-test:
     uses: ./.github/workflows/lint-and-test.yml
-
-  publish-alpha:
-    needs: lint-and-test
-    uses: ./.github/workflows/alpha-publish.yml
-    secrets: inherit


### PR DESCRIPTION
# Description

We publish an alpha release on NPM and GitHub Registry for every PR update. We will create too many alpha releases.

This PR changes the workflow to publish an alpha release only on manual triggering of the workflow.

# Checklist

<!-- Append "N/A" at the end of the item to indicate if it's not applicable -->
<!-- E.g. - [ ] ~updated storybook~ N/A, no new components -->
<!-- Prepend "POST-MERGE: " to indicate it will be completed after the merge -->
<!-- E.g. - [ ] POST-MERGE: ramp the feature flag -->

- [x] My PR represents one logical piece of work
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that prove my fix is effective or that my feature works N/A
