### PR TITLE
ci: send Slack notifications for new issues, PRs and comments

### DIFF
--- a/.github/workflows/issue-pr-slack-notification.yml
+++ b/.github/workflows/issue-pr-slack-notification.yml
@@ -1,0 +1,47 @@
+name: Slack Notifications
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "${{ github.event_name == 'issues' && 'New Issue' || github.event_name == 'pull_request' && 'New Pull Request' || 'New Comment' }}"
+            blocks:
+              - type: "header"
+                text:
+                  type: "plain_text"
+                  text: "${{ github.event_name == 'issues' && 'New Issue' || github.event_name == 'pull_request' && 'New Pull Request' || 'New Comment' }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "*Repository:* ${{ github.repository }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "*Title:* ${{ github.event.issue.title || github.event.pull_request.title }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *Created by:* ${{ github.event.sender.login }}
+              - type: "section"
+                fields:
+                  - type: "mrkdwn"
+                    text: |
+                      *Link:* ${{ github.event.issue.html_url || github.event.pull_request.html_url || github.event.comment.html_url }}


### PR DESCRIPTION
# Description

This PR sets up a GH Workflow that automatically sends a Slack message to the #eng-public-repo-notifications channel when a new issue, PR or comment is created in this repo. This is to make sure we don't miss people's messages and provide a timely response.

# Checklist

<!-- Append "N/A" at the end of the item to indicate if it's not applicable -->
<!-- E.g. - [ ] ~updated storybook~ N/A, no new components -->
<!-- Prepend "POST-MERGE: " to indicate it will be completed after the merge -->
<!-- E.g. - [ ] POST-MERGE: ramp the feature flag -->

- [x] My PR represents one logical piece of work
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that prove my fix is effective or that my feature works N/A
