### PR TITLE
fix: incorrect package.json main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@getvero/tracking",
 	"version": "2.0.0",
 	"description": "The official JavaScript/TypeScript SDK for tracking user properties and events on Vero",
-	"main": "dist/index.js",
+	"main": "dist/index.cjs",
 	"module": "dist/index.mjs",
 	"types": "dist/index.d.ts",
 	"files": [


### PR DESCRIPTION
# Description

The package.json's `main` field points to `dist/index.js` file which doesn't exist.

This PR updates the `main` field to point to `dist/index.cjs` instead.

# Checklist

<!-- Append "N/A" at the end of the item to indicate if it's not applicable -->
<!-- E.g. - [ ] ~updated storybook~ N/A, no new components -->
<!-- Prepend "POST-MERGE: " to indicate it will be completed after the merge -->
<!-- E.g. - [ ] POST-MERGE: ramp the feature flag -->

- [x] My PR represents one logical piece of work
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that prove my fix is effective or that my feature works N/A
