### PR TITLE
build: fix alpha-publish pipeline failing on creating PR comment

### DIFF
--- a/.github/workflows/alpha-publish.yml
+++ b/.github/workflows/alpha-publish.yml
@@ -60,10 +60,18 @@ jobs:
             const packageName = require('./package.json').name;
             const newVersion = '${{ steps.update_version.outputs.new_version }}';
             
+            const issues = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:${context.ref.replace('refs/heads/', '')}`
+            })
+            const pr = context.issue.number || issues.data[0].number
+
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: pr,
               body: `🎉 Package published successfully!\n\n` +
                     `📦 **Package:** \`${packageName}\`\n` +
                     `📌 **Version:** \`${newVersion}\`\n\n` +


### PR DESCRIPTION
# Description

When we trigger the alpha-publish workflow through `workflow_dispatch`, `context.issue.number` isn't available, causing the workflow to fail to comment on the corresponding PRs.

This PR fixes that by finding the issue number if `context.issue.number` isn't available. 

# Checklist

<!-- Append "N/A" at the end of the item to indicate if it's not applicable -->
<!-- E.g. - [ ] ~updated storybook~ N/A, no new components -->
<!-- Prepend "POST-MERGE: " to indicate it will be completed after the merge -->
<!-- E.g. - [ ] POST-MERGE: ramp the feature flag -->

- [x] My PR represents one logical piece of work
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that prove my fix is effective or that my feature works N/A
