### PR TITLE
feat: add conversion ID support

### DIFF
--- a/src/conversion-id-store.test.ts
+++ b/src/conversion-id-store.test.ts
@@ -1,0 +1,169 @@
+import LocalStorageMock from '../test/local-storage-mock';
+import {
+	LegacySessionCookieConversionIdStore,
+	SessionStorageConversionIdStore,
+} from './conversion-id-store';
+import * as getVeroConvParamModule from './utils/getVeroConvParam';
+
+jest.mock('./utils/isBrowser');
+jest.mock('./utils/getVeroConvParam');
+
+describe('TESTING SessionStorageConversionIdStore', () => {
+	let sessionStorageConversionIdStore: SessionStorageConversionIdStore;
+
+	beforeEach(() => {
+		Object.defineProperty(global, 'sessionStorage', {
+			value: new LocalStorageMock(),
+			writable: true,
+		});
+		jest.spyOn(getVeroConvParamModule, 'default').mockReturnValue(null);
+	});
+
+	afterEach(() => {
+		Object.defineProperty(global, 'sessionStorage', {
+			value: undefined,
+			writable: true,
+		});
+		jest.clearAllMocks();
+	});
+
+	describe('WHEN constructor is called with vero_conv in URL', () => {
+		beforeEach(() => {
+			jest
+				.mocked(getVeroConvParamModule.default)
+				.mockReturnValue('test-conversion-id');
+			sessionStorageConversionIdStore = new SessionStorageConversionIdStore({
+				keyNamespace: 'test',
+			});
+		});
+
+		it('SHOULD extract and store the conversion ID to sessionStorage', () => {
+			expect(sessionStorage.getItem('test:__vero_conv')).toBe(
+				'test-conversion-id',
+			);
+		});
+	});
+
+	describe('WHEN constructor is called without vero_conv in URL', () => {
+		beforeEach(() => {
+			jest.mocked(getVeroConvParamModule.default).mockReturnValue(null);
+			sessionStorageConversionIdStore = new SessionStorageConversionIdStore({
+				keyNamespace: 'test',
+			});
+		});
+
+		it('SHOULD not store anything to sessionStorage', () => {
+			expect(sessionStorage.getItem('test:__vero_conv')).toBeNull();
+		});
+	});
+
+	describe('WHEN get is called', () => {
+		beforeEach(() => {
+			sessionStorageConversionIdStore = new SessionStorageConversionIdStore({
+				keyNamespace: 'test',
+			});
+		});
+
+		it('SHOULD return the conversion ID if it exists', () => {
+			sessionStorage.setItem('test:__vero_conv', 'stored-conversion-id');
+			expect(sessionStorageConversionIdStore.get()).toBe(
+				'stored-conversion-id',
+			);
+		});
+
+		it('SHOULD return undefined if no conversion ID is stored', () => {
+			sessionStorage.removeItem('test:__vero_conv');
+			expect(sessionStorageConversionIdStore.get()).toBeUndefined();
+		});
+	});
+});
+
+describe('TESTING LegacySessionCookieConversionIdStore', () => {
+	let legacySessionCookieConversionIdStore: LegacySessionCookieConversionIdStore;
+
+	beforeEach(() => {
+		Object.defineProperty(global, 'document', {
+			value: {
+				cookie: '',
+			},
+			writable: true,
+		});
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('WHEN constructor is called with vero_conv in URL', () => {
+		beforeEach(() => {
+			jest
+				.mocked(getVeroConvParamModule.default)
+				.mockReturnValue('test-conversion-id');
+			legacySessionCookieConversionIdStore =
+				new LegacySessionCookieConversionIdStore({});
+		});
+
+		it('SHOULD extract and store the conversion ID to cookies', () => {
+			expect(document.cookie).toContain('__vero_conv=test-conversion-id');
+		});
+	});
+
+	describe('WHEN constructor is called with vero_conv in URL and cookieDomain option', () => {
+		beforeEach(() => {
+			jest
+				.mocked(getVeroConvParamModule.default)
+				.mockReturnValue('test-conversion-id');
+			legacySessionCookieConversionIdStore =
+				new LegacySessionCookieConversionIdStore({
+					cookieDomain: 'example.com',
+				});
+		});
+
+		it('SHOULD store the conversion ID with domain in cookies', () => {
+			expect(document.cookie).toContain('__vero_conv=test-conversion-id');
+			expect(document.cookie).toContain('domain=.example.com');
+		});
+	});
+
+	describe('WHEN constructor is called without vero_conv in URL', () => {
+		beforeEach(() => {
+			jest.mocked(getVeroConvParamModule.default).mockReturnValue(null);
+			legacySessionCookieConversionIdStore =
+				new LegacySessionCookieConversionIdStore();
+		});
+
+		it('SHOULD not store anything to cookies', () => {
+			expect(document.cookie).toBe('');
+		});
+	});
+
+	describe('WHEN get is called', () => {
+		beforeEach(() => {
+			legacySessionCookieConversionIdStore =
+				new LegacySessionCookieConversionIdStore();
+		});
+
+		it('SHOULD return the conversion ID if it exists in cookies', () => {
+			document.cookie = '__vero_conv=stored-conversion-id';
+			expect(legacySessionCookieConversionIdStore.get()).toBe(
+				'stored-conversion-id',
+			);
+		});
+
+		it('SHOULD return undefined if no conversion ID cookie exists', () => {
+			document.cookie = '';
+			expect(legacySessionCookieConversionIdStore.get()).toBeUndefined();
+		});
+
+		it('SHOULD return undefined if conversion ID cookie has empty value', () => {
+			document.cookie = '__vero_conv=';
+			expect(legacySessionCookieConversionIdStore.get()).toBeUndefined();
+		});
+
+		it('SHOULD return the correct value when multiple cookies exist', () => {
+			document.cookie =
+				'other_cookie=value; __vero_conv=my-conv-id; another=test';
+			expect(legacySessionCookieConversionIdStore.get()).toBe('my-conv-id');
+		});
+	});
+});

--- a/src/conversion-id-store.ts
+++ b/src/conversion-id-store.ts
@@ -1,0 +1,87 @@
+import getVeroConvParam from './utils/getVeroConvParam';
+import isBrowser from './utils/isBrowser';
+import normalizeCookieDomainForSubdomains from './utils/normalizeCookieDomainForSubdomains';
+
+export interface ConversionIdStore {
+	get(): string | undefined;
+}
+
+interface SessionStorageConversionIdStoreOptions {
+	keyNamespace: string;
+}
+
+export class SessionStorageConversionIdStore implements ConversionIdStore {
+	private readonly key: string;
+
+	constructor(options: SessionStorageConversionIdStoreOptions) {
+		if (!isBrowser() || typeof sessionStorage === 'undefined') {
+			throw new Error(
+				'sessionStorage is not available (is this a browser environment?)',
+			);
+		}
+		this.key = `${options.keyNamespace}:__vero_conv`;
+		this.extractAndStoreFromUrl();
+	}
+
+	get(): string | undefined {
+		return sessionStorage.getItem(this.key) ?? undefined;
+	}
+
+	private extractAndStoreFromUrl(): void {
+		const veroConv = getVeroConvParam();
+		if (veroConv) {
+			sessionStorage.setItem(this.key, veroConv);
+		}
+	}
+}
+
+interface LegacySessionCookieConversionIdStoreOptions {
+	cookieDomain?: string;
+}
+
+export class LegacySessionCookieConversionIdStore implements ConversionIdStore {
+	private static readonly COOKIE_NAME = '__vero_conv';
+	private readonly cookieDomain?: string;
+
+	constructor(options: LegacySessionCookieConversionIdStoreOptions = {}) {
+		if (!isBrowser()) {
+			throw new Error(
+				'Creating LegacySessionCookieConversionIdStore in an invalid environment (is this a browser environment?)',
+			);
+		}
+		this.cookieDomain = options.cookieDomain
+			? normalizeCookieDomainForSubdomains(options.cookieDomain)
+			: undefined;
+		this.extractAndStoreFromUrl();
+	}
+
+	get(): string | undefined {
+		const cookies = document.cookie.split(';');
+		for (const cookie of cookies) {
+			const [name, ...valueParts] = cookie.trim().split('=');
+			const value = valueParts.join('=');
+			if (name === LegacySessionCookieConversionIdStore.COOKIE_NAME) {
+				let decodedValue: string;
+				try {
+					decodedValue = decodeURIComponent(value);
+				} catch {
+					decodedValue = value;
+				}
+
+				return decodedValue || undefined;
+			}
+		}
+		return undefined;
+	}
+
+	private extractAndStoreFromUrl(): void {
+		const veroConv = getVeroConvParam();
+		if (veroConv) {
+			let cookieString = `${LegacySessionCookieConversionIdStore.COOKIE_NAME}=${encodeURIComponent(veroConv)}; path=/`;
+			if (this.cookieDomain) {
+				cookieString += `; domain=${this.cookieDomain}`;
+			}
+			document.cookie = cookieString;
+		}
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,11 @@ export type {
 	EventTrackRequest,
 } from './tracker';
 export {
+	type ConversionIdStore,
+	SessionStorageConversionIdStore,
+	LegacySessionCookieConversionIdStore,
+} from './conversion-id-store';
+export {
 	type IdentityStore,
 	LocalStorageIdentityStore,
 } from './identity-store';

--- a/src/site-visited-store.ts
+++ b/src/site-visited-store.ts
@@ -1,4 +1,5 @@
 import isBrowser from './utils/isBrowser';
+import normalizeCookieDomainForSubdomains from './utils/normalizeCookieDomainForSubdomains';
 
 export interface SiteVisitedStore {
 	hasVisited(userId: string): boolean;
@@ -58,7 +59,9 @@ export class LegacySessionCookieSiteVisitedStore implements SiteVisitedStore {
 				'Creating SessionCookieSiteVisitedStore in an invalid environment (is this a browser environment?)',
 			);
 		}
-		this.cookieDomain = options.cookieDomain;
+		this.cookieDomain = options.cookieDomain
+			? normalizeCookieDomainForSubdomains(options.cookieDomain)
+			: undefined;
 	}
 
 	hasVisited() {
@@ -74,7 +77,7 @@ export class LegacySessionCookieSiteVisitedStore implements SiteVisitedStore {
 	setVisited() {
 		let cookieString = `${LegacySessionCookieSiteVisitedStore.COOKIE_NAME}=true; path=/`;
 		if (this.cookieDomain) {
-			cookieString += `; domain=.${this.cookieDomain}`;
+			cookieString += `; domain=${this.cookieDomain}`;
 		}
 		document.cookie = cookieString;
 	}
@@ -82,7 +85,7 @@ export class LegacySessionCookieSiteVisitedStore implements SiteVisitedStore {
 	clear() {
 		let cookieString = `${LegacySessionCookieSiteVisitedStore.COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
 		if (this.cookieDomain) {
-			cookieString += `; domain=.${this.cookieDomain}`;
+			cookieString += `; domain=${this.cookieDomain}`;
 		}
 		document.cookie = cookieString;
 	}

--- a/src/tracker.test.ts
+++ b/src/tracker.test.ts
@@ -1,5 +1,6 @@
 import fetchMock from '@fetch-mock/jest';
 import LocalStorageMock from '../test/local-storage-mock';
+import type { ConversionIdStore } from './conversion-id-store';
 import type { IdentityStore } from './identity-store';
 import Tracker from './tracker';
 import * as getDefaultReservedUserDataModule from './utils/getDefaultReservedUserData';
@@ -10,6 +11,7 @@ import * as isBrowserModule from './utils/isBrowser';
 jest.mock('./utils/isBrowser');
 jest.mock('./utils/getDefaultReservedUserData');
 jest.mock('./utils/getHostname');
+jest.mock('./utils/getVeroConvParam');
 
 describe('TESTING Tracker', () => {
 	beforeEach(() => {
@@ -489,6 +491,177 @@ describe('TESTING Tracker', () => {
 					'test-user-id',
 					'test@example.com',
 				);
+			});
+		});
+
+		describe('WHEN a custom conversionIdStore is supplied', () => {
+			let tracker: Tracker;
+			let conversionIdStore: ConversionIdStore;
+
+			beforeEach(() => {
+				conversionIdStore = {
+					get: jest.fn().mockReturnValue('test-conversion-id'),
+				};
+				tracker = new Tracker({
+					trackingApiKey: 'test-api-key',
+					conversionIdStore: conversionIdStore,
+				});
+			});
+
+			describe('WHEN event.track is called', () => {
+				beforeEach(async () => {
+					jest.useFakeTimers();
+
+					await tracker.event.track({
+						identity: {
+							userId: 'test-user-id',
+							email: 'test@example.com',
+						},
+						eventName: 'test-event-name',
+						data: {
+							test: 'test',
+						},
+					});
+				});
+
+				afterEach(() => {
+					jest.useRealTimers();
+				});
+
+				it('SHOULD include the conversion ID from the store in the request', async () => {
+					expect(fetch).toHavePostedTimes(
+						1,
+						'https://api.getvero.com/api/v2/events/track?tracking_api_key=test-api-key',
+						{
+							body: {
+								identity: {
+									id: 'test-user-id',
+									email: 'test@example.com',
+								},
+								event_name: 'test-event-name',
+								data: {
+									test: 'test',
+								},
+								extras: {
+									created_at: new Date().toISOString(),
+									vero_conv: 'test-conversion-id',
+								},
+							},
+						},
+					);
+				});
+
+				it('SHOULD call the conversionIdStore.get method', () => {
+					expect(conversionIdStore.get).toHaveBeenCalled();
+				});
+			});
+
+			describe('WHEN event.track is called with explicit veroConv in extras', () => {
+				beforeEach(async () => {
+					jest.useFakeTimers();
+
+					await tracker.event.track({
+						identity: {
+							userId: 'test-user-id',
+							email: 'test@example.com',
+						},
+						eventName: 'test-event-name',
+						data: {
+							test: 'test',
+						},
+						extras: {
+							source: 'test-source',
+							createdAt: '2024-01-01T00:00:00.000Z',
+							veroConv: 'explicit-conversion-id',
+						},
+					});
+				});
+
+				afterEach(() => {
+					jest.useRealTimers();
+				});
+
+				it('SHOULD use the explicit veroConv instead of the store value', async () => {
+					expect(fetch).toHavePostedTimes(
+						1,
+						'https://api.getvero.com/api/v2/events/track?tracking_api_key=test-api-key',
+						{
+							body: {
+								identity: {
+									id: 'test-user-id',
+									email: 'test@example.com',
+								},
+								event_name: 'test-event-name',
+								data: {
+									test: 'test',
+								},
+								extras: {
+									source: 'test-source',
+									created_at: '2024-01-01T00:00:00.000Z',
+									vero_conv: 'explicit-conversion-id',
+								},
+							},
+						},
+					);
+				});
+			});
+		});
+
+		describe('WHEN no conversionIdStore is supplied and conversionIdStore.get returns undefined', () => {
+			let tracker: Tracker;
+			let conversionIdStore: ConversionIdStore;
+
+			beforeEach(() => {
+				conversionIdStore = {
+					get: jest.fn().mockReturnValue(undefined),
+				};
+				tracker = new Tracker({
+					trackingApiKey: 'test-api-key',
+					conversionIdStore: conversionIdStore,
+				});
+			});
+
+			describe('WHEN event.track is called', () => {
+				beforeEach(async () => {
+					jest.useFakeTimers();
+
+					await tracker.event.track({
+						identity: {
+							userId: 'test-user-id',
+							email: 'test@example.com',
+						},
+						eventName: 'test-event-name',
+						data: {
+							test: 'test',
+						},
+					});
+				});
+
+				afterEach(() => {
+					jest.useRealTimers();
+				});
+
+				it('SHOULD NOT include vero_conv in the request extras', async () => {
+					expect(fetch).toHavePostedTimes(
+						1,
+						'https://api.getvero.com/api/v2/events/track?tracking_api_key=test-api-key',
+						{
+							body: {
+								identity: {
+									id: 'test-user-id',
+									email: 'test@example.com',
+								},
+								event_name: 'test-event-name',
+								data: {
+									test: 'test',
+								},
+								extras: {
+									created_at: new Date().toISOString(),
+								},
+							},
+						},
+					);
+				});
 			});
 		});
 	});
@@ -1098,6 +1271,120 @@ describe('TESTING Tracker', () => {
 							localStorage.getItem('test-hash:__vero_tracking_email'),
 						).toBe('different@example.com');
 					});
+				});
+			});
+
+			describe('WHEN sessionStorage has a conversion ID stored', () => {
+				beforeEach(async () => {
+					jest.useFakeTimers();
+
+					sessionStorage.setItem(
+						'test-hash:__vero_conv',
+						'stored-conversion-id',
+					);
+
+					await tracker.event.track({
+						identity: {
+							userId: 'test-user-id',
+							email: 'test@example.com',
+						},
+						eventName: 'test-event-with-conversion',
+						data: {
+							test: 'test',
+						},
+					});
+				});
+
+				afterEach(() => {
+					jest.useRealTimers();
+					sessionStorage.removeItem('test-hash:__vero_conv');
+				});
+
+				it('SHOULD include the conversion ID from sessionStorage in the request', async () => {
+					expect(fetch).toHavePostedTimes(
+						1,
+						'https://api.getvero.com/api/v2/events/track?tracking_api_key=test-api-key',
+						{
+							body: {
+								identity: {
+									id: 'test-user-id',
+									email: 'test@example.com',
+								},
+								event_name: 'test-event-with-conversion',
+								data: {
+									test: 'test',
+									language: 'en',
+									timezone: 10,
+									ianaTimezone: 'Australia/Sydney',
+									userAgent:
+										'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
+								},
+								extras: {
+									source: 'hostname.example.com',
+									created_at: new Date().toISOString(),
+									vero_conv: 'stored-conversion-id',
+								},
+							},
+						},
+					);
+				});
+			});
+
+			describe('WHEN event.track is called with explicit veroConv in extras', () => {
+				beforeEach(async () => {
+					sessionStorage.setItem(
+						'test-hash:__vero_conv',
+						'stored-conversion-id',
+					);
+
+					await tracker.event.track({
+						identity: {
+							userId: 'test-user-id',
+							email: 'test@example.com',
+						},
+						eventName: 'test-event-name',
+						data: {
+							test: 'test',
+						},
+						extras: {
+							source: 'custom-source',
+							createdAt: '2024-01-01T00:00:00.000Z',
+							veroConv: 'explicit-conversion-id',
+						},
+					});
+				});
+
+				afterEach(() => {
+					sessionStorage.removeItem('test-hash:__vero_conv');
+				});
+
+				it('SHOULD use the explicit veroConv instead of the sessionStorage value', async () => {
+					expect(fetch).toHavePostedTimes(
+						1,
+						'https://api.getvero.com/api/v2/events/track?tracking_api_key=test-api-key',
+						{
+							body: {
+								identity: {
+									id: 'test-user-id',
+									email: 'test@example.com',
+								},
+								event_name: 'test-event-name',
+								data: {
+									test: 'test',
+									language: 'en',
+									timezone: 10,
+									ianaTimezone: 'Australia/Sydney',
+									userAgent:
+										'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
+								},
+								extras: {
+									source: 'custom-source',
+									created_at: '2024-01-01T00:00:00.000Z',
+									vero_conv: 'explicit-conversion-id',
+								},
+							},
+						},
+					);
 				});
 			});
 		});

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -1,4 +1,8 @@
 import {
+	type ConversionIdStore,
+	SessionStorageConversionIdStore,
+} from './conversion-id-store';
+import {
 	type IdentityStore,
 	LocalStorageIdentityStore,
 } from './identity-store';
@@ -65,6 +69,23 @@ export interface TrackerOptions {
 	 * instead of {@link LegacySessionCookieSiteVisitedStore}.
 	 */
 	siteVisitedStore?: SiteVisitedStore;
+	/**
+	 * Stores the conversion ID extracted from the `vero_conv` query parameter in the URL.
+	 *
+	 * By default, in the browser environment, the {@link SessionStorageConversionIdStore} is used.
+	 * When the SDK is initialized and a `vero_conv` query parameter is present in the URL,
+	 * the value is stored in this store and attached to each event tracking request.
+	 *
+	 * This SDK also includes a {@link LegacySessionCookieConversionIdStore} that uses Session Cookies
+	 * to store the conversion ID. This is handy if you are migrating from a legacy setup and want to
+	 * keep identical behavior.
+	 *
+	 * Where possible, we recommend using the default {@link SessionStorageConversionIdStore}
+	 * instead of {@link LegacySessionCookieConversionIdStore}.
+	 *
+	 * @see https://help.getvero.com/vero-1/articles/conversion-tracking/
+	 */
+	conversionIdStore?: ConversionIdStore;
 }
 
 export interface NoSiteVisitEventRequest {
@@ -208,6 +229,11 @@ interface BaseEventTrackRequest {
 		 * @example "2023-05-30T04:46:31+0000"
 		 */
 		createdAt: string;
+		/**
+		 * Used for conversion tracking. This should be the `vero_conv` query parameter value received on the frontend.
+		 * @see https://help.getvero.com/vero-1/articles/conversion-tracking/
+		 */
+		veroConv?: string;
 	};
 }
 
@@ -219,6 +245,7 @@ class Tracker {
 	private readonly network: Network;
 	private readonly identityStore: IdentityStore | null;
 	private readonly siteVisitedStore: SiteVisitedStore | null;
+	private readonly conversionIdStore: ConversionIdStore | null;
 
 	constructor(options: TrackerOptions) {
 		this.network = new Network(
@@ -249,6 +276,19 @@ class Tracker {
 			} catch (e) {
 				console.error(
 					'Unable to create SessionStorageSiteVisitedStore, no site visited events will be tracked',
+					e,
+				);
+			}
+		}
+		this.conversionIdStore = options.conversionIdStore ?? null;
+		if (!this.conversionIdStore && isBrowser()) {
+			try {
+				this.conversionIdStore = new SessionStorageConversionIdStore({
+					keyNamespace: hashedTrackingKey,
+				});
+			} catch (e) {
+				console.error(
+					'Unable to create SessionStorageConversionIdStore, no vero_conv will be automatically attached to events',
 					e,
 				);
 			}
@@ -437,6 +477,8 @@ class Tracker {
 			};
 		},
 	) {
+		const conversionId =
+			request.extras?.veroConv ?? this.conversionIdStore?.get();
 		await this.network.send('/api/v2/events/track', 'POST', {
 			identity: {
 				id: request.identity.userId,
@@ -447,6 +489,7 @@ class Tracker {
 			extras: {
 				source: request.extras?.source ?? getHostname(),
 				created_at: request.extras?.createdAt ?? new Date().toISOString(),
+				...(conversionId && { vero_conv: conversionId }),
 			},
 		});
 	}

--- a/src/utils/__mocks__/getVeroConvParam.ts
+++ b/src/utils/__mocks__/getVeroConvParam.ts
@@ -1,0 +1,5 @@
+const getVeroConvParam = (): string | null => {
+	return null;
+};
+
+export default getVeroConvParam;

--- a/src/utils/getVeroConvParam.ts
+++ b/src/utils/getVeroConvParam.ts
@@ -1,0 +1,13 @@
+import isBrowser from './isBrowser';
+
+/**
+ * Extracts the `vero_conv` query parameter value from the current URL.
+ * Returns null if not in a browser environment or if the parameter is not present.
+ */
+const getVeroConvParam = (): string | null => {
+	if (!isBrowser()) return null;
+	const urlParams = new URLSearchParams(window.location.search);
+	return urlParams.get('vero_conv');
+};
+
+export default getVeroConvParam;

--- a/src/utils/normalizeCookieDomainForSubdomains.ts
+++ b/src/utils/normalizeCookieDomainForSubdomains.ts
@@ -1,0 +1,7 @@
+/**
+ * Adds a leading dot to a cookie domain if it doesn't already have one so the cookie will be set on all subdomains.
+ */
+const normalizeCookieDomainForSubdomains = (domain: string) =>
+	domain.startsWith('.') ? domain : `.${domain}`;
+
+export default normalizeCookieDomainForSubdomains;


### PR DESCRIPTION
https://linear.app/makevero/issue/ENG-702/update-trackingjs-sdk-to-handle-vero-conv-query-param-for-conversion

# Description

Implemented conversion tracking by reading the `vero_conv` value from the URL's query param and attach it to the following tracked events' `extras` object.

# Checklist

<!-- Append "N/A" at the end of the item to indicate if it's not applicable -->
<!-- E.g. - [ ] ~updated storybook~ N/A, no new components -->
<!-- Prepend "POST-MERGE: " to indicate it will be completed after the merge -->
<!-- E.g. - [ ] POST-MERGE: ramp the feature flag -->

- [x] My PR represents one logical piece of work
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation - Corresponding JSDocs updated
- [x] I have added tests that prove my fix is effective or that my feature works
