### PR TITLE
chore(deps): bump handlebars 4.7.8 → 4.7.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4098,9 +4098,9 @@
 			"dev": true
 		},
 		"node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
## Summary

Bumps transitive dev dependency `handlebars` from `4.7.8` → `4.7.9` to patch four CVEs (one critical, three high).

- Linear: ENG-1424 (sub-issue of ENG-1419)
- CVEs patched:
  - CVE-2026-33937 (critical) — JavaScript injection via AST type confusion
  - CVE-2026-33938 / 33940 / 33941 (high) — related injection vectors

## Why this is safe

- `handlebars` is a **transitive, dev-only** dependency pulled in by `conventional-changelog-writer` (part of the `semantic-release` toolchain). It is not in `package.json`.
- The existing `^4.7.7` range already permits `4.7.9` — this is a pure lockfile refresh, no manifest edit, no version pin.
- Zero call sites in `src/` or `test/` — no production runtime exposure.
- Handlebars `4.7.9` release notes flag **no breaking changes** vs `4.7.8` (security fixes plus minor internal refactors and TS type tweaks).

## Verification

- `npm test` → 5 suites, 72 tests passed
- `npm run lint` → biome clean, no issues
- `npm ls handlebars` → resolves to `4.7.9` via `semantic-release > @semantic-release/commit-analyzer > conventional-changelog-writer`
- `git diff --stat` → 1 file changed (`package-lock.json`), 3 insertions, 3 deletions — confined to the `node_modules/handlebars` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)